### PR TITLE
Add marketing landing page for InFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ InFrame is a SwiftUI app that captures a **context selfie**: it shoots the scene
 4. Browse your composites in the **Gallery** tab.
 5. Adjust preferences in **Settings**.
 
+## Marketing Page
+Share InFrame with your audience using the included landing page located at [`index.html`](index.html). The page highlights the
+core experience, showcases previews of the app, and links directly to the App Store listing so visitors can download the app
+immediately.
+
 ### Privacy & Legal Templates
 - [Privacy Policy](PRIVACY_POLICY.md)
 - [Terms of Use](TERMS_OF_USE.md)

--- a/assets/inframe-camera.svg
+++ b/assets/inframe-camera.svg
@@ -1,0 +1,33 @@
+<svg width="320" height="560" viewBox="0 0 320 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cameraBody" x1="40" y1="32" x2="280" y2="528" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2F2A83" />
+      <stop offset="1" stop-color="#4D44C4" />
+    </linearGradient>
+    <linearGradient id="cameraSky" x1="92" y1="126" x2="228" y2="258" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#63B8FF" />
+      <stop offset="1" stop-color="#87E0FF" />
+    </linearGradient>
+    <linearGradient id="cameraGround" x1="86" y1="252" x2="238" y2="392" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5AEBBC" />
+      <stop offset="1" stop-color="#35C39B" />
+    </linearGradient>
+  </defs>
+  <rect x="26" y="20" width="268" height="520" rx="42" fill="#F7F5FF" />
+  <rect x="48" y="86" width="224" height="388" rx="28" fill="url(#cameraBody)" />
+  <rect x="68" y="112" width="184" height="124" rx="20" fill="url(#cameraSky)" />
+  <rect x="68" y="236" width="184" height="104" rx="20" fill="url(#cameraGround)" />
+  <circle cx="160" cy="160" r="28" fill="#F9FAFF" opacity="0.45" />
+  <path
+    d="M188 314c14-24 40-32 56-32v82c-16 0-42 8-56 32-14-24-40-32-56-32v-82c16 0 42 8 56 32Z"
+    fill="#1B144B"
+    opacity="0.65"
+  />
+  <rect x="68" y="348" width="184" height="104" rx="20" fill="#1F1A5A" />
+  <rect x="92" y="368" width="56" height="12" rx="6" fill="#5149C6" />
+  <rect x="92" y="392" width="92" height="12" rx="6" fill="#655DEC" opacity="0.8" />
+  <circle cx="228" cy="420" r="18" fill="#FF9F6A" />
+  <rect x="120" y="464" width="80" height="24" rx="12" fill="#F1EEFF" opacity="0.7" />
+  <rect x="132" y="64" width="56" height="8" rx="4" fill="#E6E2FF" />
+  <circle cx="160" cy="48" r="10" fill="#EAE6FF" />
+</svg>

--- a/assets/inframe-gallery.svg
+++ b/assets/inframe-gallery.svg
@@ -1,0 +1,35 @@
+<svg width="320" height="560" viewBox="0 0 320 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="galleryBody" x1="32" y1="48" x2="288" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#262155" />
+      <stop offset="1" stop-color="#3C2E92" />
+    </linearGradient>
+    <linearGradient id="galleryTile1" x1="92" y1="160" x2="156" y2="240" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF6F8D" />
+      <stop offset="1" stop-color="#FF9D6F" />
+    </linearGradient>
+    <linearGradient id="galleryTile2" x1="164" y1="160" x2="228" y2="240" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6D93FF" />
+      <stop offset="1" stop-color="#85C8FF" />
+    </linearGradient>
+    <linearGradient id="galleryTile3" x1="92" y1="248" x2="156" y2="328" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7D7CFF" />
+      <stop offset="1" stop-color="#B38AFF" />
+    </linearGradient>
+    <linearGradient id="galleryTile4" x1="164" y1="248" x2="228" y2="328" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#48E0C6" />
+      <stop offset="1" stop-color="#2FB0A8" />
+    </linearGradient>
+  </defs>
+  <rect x="24" y="28" width="272" height="504" rx="44" fill="#FBF9FF" />
+  <rect x="48" y="92" width="224" height="376" rx="30" fill="url(#galleryBody)" />
+  <rect x="84" y="138" width="72" height="88" rx="18" fill="url(#galleryTile1)" />
+  <rect x="164" y="138" width="72" height="88" rx="18" fill="url(#galleryTile2)" />
+  <rect x="84" y="226" width="72" height="88" rx="18" fill="url(#galleryTile3)" />
+  <rect x="164" y="226" width="72" height="88" rx="18" fill="url(#galleryTile4)" />
+  <rect x="84" y="314" width="152" height="80" rx="20" fill="#201B54" opacity="0.65" />
+  <rect x="84" y="410" width="152" height="32" rx="12" fill="#EAE6FF" opacity="0.55" />
+  <circle cx="220" cy="426" r="12" fill="#3A32F0" />
+  <rect x="132" y="60" width="56" height="8" rx="4" fill="#E6E2FF" />
+  <circle cx="160" cy="44" r="10" fill="#EAE6FF" />
+</svg>

--- a/assets/inframe-hero.svg
+++ b/assets/inframe-hero.svg
@@ -1,0 +1,35 @@
+<svg width="360" height="640" viewBox="0 0 360 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="heroGradient" x1="54" y1="30" x2="302" y2="590" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3A32F0" />
+      <stop offset="1" stop-color="#AD6BFF" />
+    </linearGradient>
+    <linearGradient id="heroScreen" x1="108" y1="102" x2="252" y2="486" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D0B33" />
+      <stop offset="1" stop-color="#221C60" />
+    </linearGradient>
+    <linearGradient id="heroGlow" x1="132" y1="150" x2="228" y2="450" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7C74FF" stop-opacity="0.75" />
+      <stop offset="1" stop-color="#E5D7FF" stop-opacity="0.2" />
+    </linearGradient>
+  </defs>
+  <rect x="30" y="24" width="300" height="592" rx="48" fill="url(#heroGradient)" opacity="0.16" />
+  <rect x="42" y="40" width="276" height="560" rx="44" fill="#FBF9FF" />
+  <rect x="72" y="96" width="216" height="448" rx="30" fill="url(#heroScreen)" />
+  <rect x="108" y="146" width="144" height="160" rx="24" fill="#2A2668" />
+  <rect x="124" y="168" width="112" height="116" rx="20" fill="#2F89FF" opacity="0.85" />
+  <rect x="124" y="308" width="112" height="116" rx="20" fill="#FCAC4B" opacity="0.85" />
+  <rect x="108" y="454" width="144" height="56" rx="16" fill="#1D1A40" />
+  <circle cx="180" cy="482" r="18" fill="#3A32F0" />
+  <rect x="152" y="468" width="8" height="28" rx="4" fill="#FFFFFF" opacity="0.6" />
+  <rect x="200" y="468" width="8" height="28" rx="4" fill="#FFFFFF" opacity="0.6" />
+  <rect x="108" y="388" width="144" height="48" rx="12" fill="#1D1A40" opacity="0.6" />
+  <rect x="124" y="402" width="64" height="12" rx="6" fill="#4B46A6" />
+  <rect x="196" y="402" width="44" height="12" rx="6" fill="#4B46A6" />
+  <circle cx="180" cy="80" r="14" fill="#F3F2FF" />
+  <rect x="158" y="60" width="44" height="8" rx="4" fill="#E4E1FF" />
+  <rect x="98" y="520" width="164" height="30" rx="14" fill="#E7E4FF" opacity="0.6" />
+  <rect x="90" y="540" width="180" height="14" rx="7" fill="#E7E4FF" opacity="0.4" />
+  <rect x="72" y="120" width="216" height="404" rx="30" fill="url(#heroGlow)" opacity="0.45" />
+  <rect x="86" y="110" width="188" height="384" rx="26" stroke="#FFFFFF" stroke-opacity="0.08" stroke-width="2" />
+</svg>

--- a/assets/inframe-settings.svg
+++ b/assets/inframe-settings.svg
@@ -1,0 +1,24 @@
+<svg width="320" height="560" viewBox="0 0 320 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="settingsBody" x1="36" y1="40" x2="284" y2="516" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#281F58" />
+      <stop offset="1" stop-color="#423096" />
+    </linearGradient>
+  </defs>
+  <rect x="24" y="28" width="272" height="504" rx="44" fill="#FBF9FF" />
+  <rect x="48" y="92" width="224" height="376" rx="30" fill="url(#settingsBody)" />
+  <rect x="72" y="136" width="176" height="44" rx="18" fill="#1E184B" />
+  <rect x="92" y="148" width="92" height="20" rx="10" fill="#4E46C4" opacity="0.8" />
+  <rect x="72" y="200" width="176" height="44" rx="18" fill="#1E184B" />
+  <rect x="188" y="212" width="44" height="20" rx="10" fill="#48E0C6" />
+  <rect x="72" y="264" width="176" height="44" rx="18" fill="#1E184B" />
+  <rect x="188" y="276" width="44" height="20" rx="10" fill="#FF9F6A" />
+  <rect x="72" y="328" width="176" height="44" rx="18" fill="#1E184B" />
+  <rect x="188" y="340" width="44" height="20" rx="10" fill="#7D7CFF" />
+  <rect x="72" y="392" width="176" height="56" rx="22" fill="#1E184B" />
+  <rect x="92" y="410" width="88" height="16" rx="8" fill="#655DEC" opacity="0.8" />
+  <rect x="92" y="432" width="60" height="10" rx="5" fill="#5149C6" opacity="0.8" />
+  <rect x="132" y="60" width="56" height="8" rx="4" fill="#E6E2FF" />
+  <circle cx="160" cy="44" r="10" fill="#EAE6FF" />
+  <rect x="124" y="470" width="72" height="24" rx="12" fill="#F1EEFF" opacity="0.7" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>InFrame – Context Selfies that Tell the Whole Story</title>
+    <meta
+      name="description"
+      content="Capture the scene and yourself in one immersive frame. InFrame combines the rear and front cameras to create context selfies that feel alive."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <header>
+      <div class="hero">
+        <div class="hero__content">
+          <p class="section__eyebrow">Context selfies reimagined</p>
+          <h1 class="hero__headline">Capture yourself <br />inside every story</h1>
+          <p class="hero__lead">
+            InFrame stitches together the scene in front of you and the selfie you snap in the moment. Share the full story with
+            composites that show everything and keep the originals in your library when you want them.
+          </p>
+          <div class="hero__ctas">
+            <a
+              class="hero__cta-button"
+              href="https://apps.apple.com/app/inframe-context-selfie/id0000000000"
+              target="_blank"
+              rel="noopener"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M17.807 13.437c.034 3.419 3 4.556 3.035 4.571-.025.08-.475 1.629-1.569 3.228-0.946 1.385-1.923 2.764-3.47 2.795-1.519.028-2.007-.9-3.748-.9s-2.29.872-3.74.93c-1.5.058-2.648-1.492-3.602-2.873-1.964-2.853-3.463-8.071-1.45-11.596 1.002-1.742 2.797-2.847 4.747-2.875 1.474-.029 2.869 1.006 3.748 1.006.878 0 2.573-1.241 4.333-1.056.738.031 2.814.296 4.145 2.22-.108.068-2.476 1.467-2.429 4.55ZM14.835 3.486c.798-.968 1.333-2.31 1.183-3.646-1.147.046-2.533.762-3.352 1.73-.738.855-1.383 2.222-1.21 3.534 1.28.1 2.58-.65 3.379-1.618Z"
+                />
+              </svg>
+              Download on the App Store
+            </a>
+            <span class="hero__meta">Available for iPhone • Requires iOS 17</span>
+          </div>
+        </div>
+        <div class="hero__visual" aria-hidden="true">
+          <div class="hero__device">
+            <img src="assets/inframe-hero.svg" alt="" />
+          </div>
+        </div>
+      </div>
+    </header>
+    <main>
+      <section class="section">
+        <div class="features">
+          <article class="feature-card">
+            <div class="feature-card__icon">
+              <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M7 4a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3h3a2 2 0 0 1 2 2v11a3 3 0 0 1-3 3h-2.586L16 22.414 13.586 20H6a3 3 0 0 1-3-3V6a2 2 0 0 1 2-2h2Z"
+                />
+              </svg>
+            </div>
+            <h3 class="feature-card__title">Context-aware camera</h3>
+            <p class="feature-card__body">
+              Seamlessly switch between rear and front cameras to capture the scene, your selfie, and the composite without losing
+              the moment.
+            </p>
+          </article>
+          <article class="feature-card">
+            <div class="feature-card__icon">
+              <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M4 4h16a2 2 0 0 1 2 2v12.5a1.5 1.5 0 0 1-1.5 1.5H5.5A1.5 1.5 0 0 1 4 18.5V4Zm6 3v4h4V7h-4Zm0 6v4h4v-4h-4Zm-5 0v4h4v-4H5Zm10 0v4h4v-4h-4Zm-10-6v4h4V7H5Zm10 0v4h4V7h-4Z"
+                />
+              </svg>
+            </div>
+            <h3 class="feature-card__title">Gallery built for sharing</h3>
+            <p class="feature-card__body">
+              Browse every context selfie in an immersive grid. Tap to relive the moment, zoom in on the details, and share in one
+              tap.
+            </p>
+          </article>
+          <article class="feature-card">
+            <div class="feature-card__icon">
+              <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M10.75 4.5 9.5 2h5l-1.25 2.5h3.75L22 9l-5 9H7l-5-9 4.75-4.5h4Z"
+                />
+              </svg>
+            </div>
+            <h3 class="feature-card__title">Control your experience</h3>
+            <p class="feature-card__body">
+              Keep the originals when you need them, remove ads, and fine-tune how composites are saved—all from one simple settings
+              panel.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section showcase">
+        <div>
+          <p class="section__eyebrow">See it in action</p>
+          <h2 class="section__title">Composites that spark conversation</h2>
+          <p class="section__description">
+            InFrame captures the world in front of you, layers in your reaction, and balances the exposure for a polished look.
+            These previews highlight the camera flow, the gallery, and the customizable settings that make every session yours.
+          </p>
+        </div>
+        <div class="showcase__grid">
+          <figure>
+            <img src="assets/inframe-camera.svg" alt="Camera screen preview from InFrame showing a capture session" />
+            <figcaption>Start with the rear camera and line up your scene. Tap once to snap and prepare for your selfie.</figcaption>
+          </figure>
+          <figure>
+            <img src="assets/inframe-gallery.svg" alt="Gallery preview from InFrame showing composite selfies in a grid" />
+            <figcaption>
+              Every context selfie is saved to a sleek gallery for quick browsing, sharing, and revisiting the story later.
+            </figcaption>
+          </figure>
+          <figure>
+            <img src="assets/inframe-settings.svg" alt="Settings screen preview showing toggles for saving originals and removing ads" />
+            <figcaption>
+              Decide whether to keep originals, manage storage, and choose an ad-free experience with a simple upgrade.
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section class="section">
+        <p class="section__eyebrow">Loved by creators</p>
+        <h2 class="section__title">The reception has been instant</h2>
+        <p class="section__description">
+          Photographers, travel vloggers, and families are using InFrame to capture the energy of the moment without sacrificing
+          spontaneity. Here's what they're saying after a few weeks with the app.
+        </p>
+        <div class="testimonials">
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              “InFrame finally lets me record the scene and my reaction at the same time. My followers love how personal my travel
+              stories feel now.”
+            </p>
+            <div class="testimonial__author">
+              <div>
+                Alex Chen
+                <div class="testimonial__role">Travel Filmmaker</div>
+              </div>
+            </div>
+          </article>
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              “I use it for family events and the composites are instant keepsakes. It's like reliving the moment right after it
+              happens.”
+            </p>
+            <div class="testimonial__author">
+              <div>
+                Priya Patel
+                <div class="testimonial__role">Mom &amp; Photographer</div>
+              </div>
+            </div>
+          </article>
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              “The gallery is gorgeous and the automatic exposure balance is spot on. It's become my go-to tool for behind-the-scenes
+              content.”
+            </p>
+            <div class="testimonial__author">
+              <div>
+                Jordan Reeves
+                <div class="testimonial__role">Content Creator</div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <p class="section__eyebrow">Simple pricing</p>
+        <h2 class="section__title">Start free, grow with InFrame+</h2>
+        <p class="section__description">
+          Download InFrame for free to capture unlimited context selfies with tasteful ads, or upgrade to unlock premium controls and
+          an ad-free gallery that keeps you immersed in the moment.
+        </p>
+        <div class="pricing">
+          <article class="pricing-card">
+            <h3>InFrame</h3>
+            <p class="pricing-card__price">Free</p>
+            <p class="pricing-card__description">Everything you need to capture context selfies and share them instantly.</p>
+            <ul>
+              <li>Unlimited composites saved to your library</li>
+              <li>Optional saving of original shots</li>
+              <li>Context selfie gallery optimized for sharing</li>
+            </ul>
+            <a
+              class="cta-panel"
+              href="https://apps.apple.com/app/inframe-context-selfie/id0000000000"
+              target="_blank"
+              rel="noopener"
+            >
+              Download now
+            </a>
+          </article>
+          <article class="pricing-card">
+            <h3>InFrame+</h3>
+            <p class="pricing-card__price">$2.99</p>
+            <p class="pricing-card__description">Upgrade for creators who want uninterrupted sessions and premium controls.</p>
+            <ul>
+              <li>Remove banner and interstitial ads</li>
+              <li>Advanced composite fine-tuning</li>
+              <li>Priority updates &amp; new creative filters</li>
+            </ul>
+            <a
+              class="cta-panel"
+              href="https://apps.apple.com/app/inframe-context-selfie/id0000000000"
+              target="_blank"
+              rel="noopener"
+            >
+              Go InFrame+
+            </a>
+          </article>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer__content">
+        <span class="footer__brand">© <span id="year"></span> InFrame Labs</span>
+        <div class="footer__links">
+          <a href="PRIVACY_POLICY.md">Privacy Policy</a>
+          <a href="TERMS_OF_USE.md">Terms of Use</a>
+          <a href="IN_APP_DISCLOSURES.md">Disclosures</a>
+        </div>
+        <span>Made with SwiftUI in San Francisco.</span>
+      </div>
+    </footer>
+    <script>
+      const yearElement = document.getElementById("year");
+      yearElement.textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,378 @@
+:root {
+  color-scheme: light;
+  --gradient-start: #3a32f0;
+  --gradient-end: #ad6bff;
+  --text-primary: #12121a;
+  --text-muted: #5f6073;
+  --surface: #ffffff;
+  --surface-alt: #f5f5ff;
+  --accent: #3a32f0;
+  --accent-dark: #2720b8;
+  --shadow-soft: 0 20px 40px rgba(34, 20, 78, 0.15);
+  --shadow-hero: 0 35px 80px rgba(58, 50, 240, 0.28);
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: radial-gradient(circle at 0% 0%, rgba(58, 50, 240, 0.08), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(173, 107, 255, 0.08), transparent 55%),
+    #f9f9ff;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+header {
+  padding: 64px 5vw 48px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 56px;
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.hero__headline {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  line-height: 1.05;
+  margin: 0 0 24px;
+}
+
+.hero__lead {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  max-width: 540px;
+  margin-bottom: 32px;
+}
+
+.hero__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.hero__cta-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 22px;
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+  border-radius: 999px;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--shadow-hero);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__cta-button svg {
+  width: 20px;
+  height: 20px;
+}
+
+.hero__cta-button:hover,
+.hero__cta-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 60px rgba(58, 50, 240, 0.36);
+}
+
+.hero__meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.hero__visual {
+  position: relative;
+  padding: 32px;
+}
+
+.hero__visual::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 36px;
+  background: linear-gradient(135deg, rgba(58, 50, 240, 0.18), rgba(173, 107, 255, 0.18));
+  filter: blur(24px);
+  transform: translate3d(0, 16px, 0);
+  z-index: 0;
+}
+
+.hero__device {
+  position: relative;
+  border-radius: 40px;
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+  padding: 16px;
+  z-index: 1;
+}
+
+main {
+  padding: 0 5vw 96px;
+}
+
+.section {
+  max-width: 1120px;
+  margin: 0 auto 96px;
+}
+
+.section__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.section__title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0 0 16px;
+}
+
+.section__description {
+  color: var(--text-muted);
+  margin: 0 0 48px;
+  max-width: 720px;
+}
+
+.features {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature-card {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.feature-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(58, 50, 240, 0.16), rgba(173, 107, 255, 0.16));
+}
+
+.feature-card__title {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.feature-card__body {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.showcase {
+  background: var(--surface-alt);
+  border-radius: 40px;
+  padding: 48px;
+  display: grid;
+  gap: 40px;
+}
+
+.showcase__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 32px;
+}
+
+.showcase figure {
+  margin: 0;
+  background: var(--surface);
+  border-radius: 32px;
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+.showcase figcaption {
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.testimonials {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.testimonial {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.testimonial__quote {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.testimonial__author {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.testimonial__role {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pricing {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.pricing-card {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 32px 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.pricing-card__price {
+  font-size: 2.5rem;
+  margin: 0;
+}
+
+.pricing-card__description {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.pricing-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.pricing-card li::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  margin-right: 8px;
+}
+
+.cta-panel {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  background: rgba(58, 50, 240, 0.12);
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--accent);
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.cta-panel:hover,
+.cta-panel:focus-visible {
+  background: rgba(58, 50, 240, 0.18);
+  transform: translateY(-1px);
+}
+
+footer {
+  padding: 48px 5vw 64px;
+  background: #0b0b12;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.footer__content {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.footer__brand {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 0.9rem;
+}
+
+.footer__links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer__links a:hover,
+.footer__links a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  header {
+    padding-top: 48px;
+  }
+
+  .hero {
+    gap: 40px;
+  }
+
+  .showcase {
+    padding: 32px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone marketing landing page with a hero, testimonials, pricing, and App Store CTAs
- introduce stylized SVG mockups to showcase the camera, gallery, and settings screens
- document the new marketing page in the README for easy discovery

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbf87a53f4832a87096fa3119d3e49