### PR TITLE
Add contact page for email outreach

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact InFrame – The Context Selfie Camera</title>
+    <meta
+      name="description"
+      content="Reach the InFrame team for product questions, support, and partnership opportunities."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <header class="contact-header">
+      <div class="contact-header__inner">
+        <a class="contact-header__home" href="index.html">← Back to InFrame</a>
+        <p class="section__eyebrow">Get in touch</p>
+        <h1 class="contact-header__title">Contact InFrame</h1>
+        <p class="contact-header__lead">
+          We’d love to hear from you. Email the team at
+          <a href="mailto:3dlight.mail@gmail.com">3dlight.mail@gmail.com</a> for support, media inquiries, or partnership
+          conversations.
+        </p>
+        <a class="hero__cta-button contact__email-link" href="mailto:3dlight.mail@gmail.com">
+          Email 3dlight.mail@gmail.com
+        </a>
+      </div>
+    </header>
+    <main>
+      <section class="section contact-info">
+        <div class="contact-info__card">
+          <h2>How we can help</h2>
+          <p>
+            Send us a note and we’ll respond as soon as possible. Sharing a few details about your request helps us connect you
+            with the right teammate.
+          </p>
+          <ul class="contact-info__list">
+            <li>
+              <strong>Product support</strong>
+              Troubleshoot an issue, suggest a new feature, or ask about upcoming updates.
+            </li>
+            <li>
+              <strong>Press &amp; media</strong>
+              Request interviews, assets, and talking points for coverage of InFrame.
+            </li>
+            <li>
+              <strong>Partnerships</strong>
+              Explore collaborations, integrations, and creative campaigns with our team.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer__content">
+        <span class="footer__brand">© <span id="year"></span> InFrame Labs</span>
+        <div class="footer__links">
+          <a href="contact.html">Contact</a>
+          <a href="../PRIVACY_POLICY.md">Privacy Policy</a>
+          <a href="../TERMS_OF_USE.md">Terms of Use</a>
+          <a href="../IN_APP_DISCLOSURES.md">Disclosures</a>
+        </div>
+        <span>Made with SwiftUI in San Francisco.</span>
+      </div>
+    </footer>
+    <script>
+      const yearElement = document.getElementById("year");
+      yearElement.textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -225,6 +225,7 @@
       <div class="footer__content">
         <span class="footer__brand">© <span id="year"></span> InFrame Labs</span>
         <div class="footer__links">
+          <a href="contact.html">Contact</a>
           <a href="../PRIVACY_POLICY.md">Privacy Policy</a>
           <a href="../TERMS_OF_USE.md">Terms of Use</a>
           <a href="../IN_APP_DISCLOSURES.md">Disclosures</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -316,6 +316,87 @@ main {
   transform: translateY(-1px);
 }
 
+.contact-header {
+  padding: 96px 5vw 48px;
+}
+
+.contact-header__inner {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.contact-header__home {
+  align-self: flex-start;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.contact-header__home:hover,
+.contact-header__home:focus-visible {
+  text-decoration: underline;
+}
+
+.contact-header__title {
+  font-size: clamp(2.5rem, 5vw, 3rem);
+  margin: 0;
+}
+
+.contact-header__lead {
+  color: var(--text-muted);
+  margin: 0 auto 8px;
+  max-width: 640px;
+}
+
+.contact__email-link {
+  align-self: center;
+}
+
+.contact-info {
+  max-width: 760px;
+}
+
+.contact-info__card {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 36px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 16px;
+}
+
+.contact-info__card h2 {
+  margin: 0;
+}
+
+.contact-info__card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.contact-info__list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: grid;
+  gap: 18px;
+}
+
+.contact-info__list strong {
+  display: block;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.contact-info__list li {
+  color: var(--text-muted);
+}
+
 footer {
   padding: 48px 5vw 64px;
   background: #0b0b12;


### PR DESCRIPTION
## Summary
- create a dedicated contact page that directs visitors to email 3dlight.mail@gmail.com
- add page-specific styling to match the site's existing look and feel
- link the new contact page from the footer navigation

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc6ca4d568832aa03e953f2c1828f6