### PR TITLE
Reduce hero image size

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -96,11 +96,16 @@ footer {
   color: rgba(244, 246, 251, 0.7);
 }
 
+.hero__visual {
+  display: flex;
+  justify-content: center;
+}
+
 .hero__visual img,
 .hero__device {
   max-width: 100%;
   height: auto;
-  max-height: 60vh;      /* limit to 60% of viewport height */
+  max-height: 50vh;      /* limit to 50% of viewport height */
   object-fit: contain;   /* keep aspect ratio */
 }
 
@@ -110,6 +115,7 @@ footer {
   padding: 1.5rem;
   backdrop-filter: blur(18px);
   box-shadow: 0 24px 60px rgba(10, 15, 30, 0.5);
+  max-width: 420px;
 }
 
 .section {


### PR DESCRIPTION
## Summary
- center the hero visual container so the hero shot doesn't stretch edge-to-edge
- shrink the hero image by lowering its max viewport height and capping the device frame width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6f4122bc832a8cd070b04f2ea7ac