### PR TITLE
Highlight new 25-shot gallery grid setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ InFrame is a SwiftUI app that captures a **context selfie**: it shoots the scene
 ## Features
 - **Camera** – Switches between rear and front cameras to capture the scene and your selfie, then saves the composite (and optionally the originals) to the photo library.
 - **Gallery** – Shows previously captured context selfies in a grid. Tap any item for a full-screen preview or explicitly request photo-library access.
-- **Settings** – Toggle whether the original scene and selfie photos should also be kept.
+- **Settings** – Toggle whether the original scene and selfie photos should also be kept, and choose between a 3×3 or 5×5 gallery grid.
 - **Advertisement** – Displays a Google AdMob banner at the bottom of the gallery and periodically shows a full-screen interstitial ad with an option to remove ads.
 
 ## Getting Started

--- a/index.html
+++ b/index.html
@@ -92,8 +92,8 @@
             </div>
             <h3 class="feature-card__title">Control the details</h3>
             <p class="feature-card__body">
-              Choose whether InFrame keeps the original scene and selfie alongside the composite, and fine-tune storage from the
-              Settings tab.
+              Choose whether InFrame keeps the original scene and selfie alongside the composite, dial in a 25-shot detail grid
+              for the gallery, and fine-tune storage from the Settings tab.
             </p>
           </article>
         </div>
@@ -120,9 +120,13 @@
             </figcaption>
           </figure>
           <figure>
-            <img src="assets/inframe-settings.PNG" alt="Settings screen preview showing toggles for saving originals and removing ads" />
+            <img
+              src="assets/inframe-settings.PNG"
+              alt="Settings screen preview showing toggles for saving originals, removing ads, and choosing the 25-shot grid"
+            />
             <figcaption>
-              Toggle saving of originals, manage storage, and explore the upgrade for an uninterrupted experience.
+              Toggle saving of originals, switch between the classic 3×3 grid and the new 5×5 detail layout, manage storage, and
+              explore the upgrade for an uninterrupted experience.
             </figcaption>
           </figure>
         </div>


### PR DESCRIPTION
## Summary
- mention the new 25-shot gallery grid setting in the marketing copy for the Settings screen
- update the Settings feature card and screenshot caption to call out the new grid option
- refresh the README feature list to document the 3×3 and 5×5 gallery grid choices

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc9c94ac64832aa9be38655be9c636