### PR TITLE
Add detail view toggle to switch between selfie and scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,37 @@
         </div>
       </section>
 
+      <section class="section detail-view">
+        <div class="detail-view__layout">
+          <div class="detail-view__copy">
+            <p class="section__eyebrow">Detail view</p>
+            <h2 class="section__title">See every capture on its own terms</h2>
+            <p class="detail-view__body">
+              Open any composite to inspect the full scene or revisit the selfie that made the moment. The new detail view toggle
+              lets you flip between the originals without losing your place in the story.
+            </p>
+            <button class="detail-view__toggle" type="button" aria-pressed="false" aria-label="Show the selfie capture">
+              Show Selfie
+            </button>
+          </div>
+          <div class="detail-view__preview" data-state="scene">
+            <img
+              src="assets/inframe-hero.jpg"
+              alt="Selfie capture displayed within the detail view"
+              class="detail-view__image detail-view__image--selfie"
+              aria-hidden="true"
+            />
+            <img
+              src="assets/inframe-gallery.jpg"
+              alt="Scene capture displayed within the detail view"
+              class="detail-view__image detail-view__image--scene is-active"
+              aria-hidden="false"
+            />
+            <span class="detail-view__badge">Scene</span>
+          </div>
+        </div>
+      </section>
+
       <section class="section">
         <p class="section__eyebrow">Creators love the context</p>
         <h2 class="section__title">Reactions from the first shoots</h2>
@@ -236,6 +267,37 @@
     <script>
       const yearElement = document.getElementById("year");
       yearElement.textContent = new Date().getFullYear();
+
+      const detailToggle = document.querySelector(".detail-view__toggle");
+      const detailPreview = document.querySelector(".detail-view__preview");
+
+      if (detailToggle && detailPreview) {
+        const detailImages = Array.from(detailPreview.querySelectorAll(".detail-view__image"));
+        const detailBadge = detailPreview.querySelector(".detail-view__badge");
+
+        detailToggle.addEventListener("click", () => {
+          const showSelfie = detailPreview.dataset.state !== "selfie";
+          detailPreview.dataset.state = showSelfie ? "selfie" : "scene";
+
+          detailImages.forEach((image) => {
+            const isSelfie = image.classList.contains("detail-view__image--selfie");
+            const shouldShow = showSelfie ? isSelfie : !isSelfie;
+            image.classList.toggle("is-active", shouldShow);
+            image.setAttribute("aria-hidden", String(!shouldShow));
+          });
+
+          if (detailBadge) {
+            detailBadge.textContent = showSelfie ? "Selfie" : "Scene";
+          }
+
+          detailToggle.textContent = showSelfie ? "Show Scene" : "Show Selfie";
+          detailToggle.setAttribute("aria-pressed", String(showSelfie));
+          detailToggle.setAttribute(
+            "aria-label",
+            showSelfie ? "Show the scene capture" : "Show the selfie capture"
+          );
+        });
+      }
     </script>
   </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -205,6 +205,89 @@ footer {
   color: rgba(244, 246, 251, 0.75);
 }
 
+.detail-view__layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.detail-view__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detail-view__body {
+  margin: 0;
+  color: rgba(244, 246, 251, 0.75);
+  max-width: 460px;
+}
+
+.detail-view__toggle {
+  align-self: flex-start;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(53, 109, 255, 0.9), rgba(122, 92, 255, 0.9));
+  color: #fff;
+  box-shadow: 0 16px 32px rgba(61, 102, 255, 0.35);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.detail-view__toggle:hover,
+.detail-view__toggle:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(61, 102, 255, 0.45);
+}
+
+.detail-view__toggle:focus-visible {
+  outline: 2px solid rgba(196, 207, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.detail-view__preview {
+  position: relative;
+  background: rgba(18, 24, 36, 0.85);
+  border-radius: 28px;
+  padding: 2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(123, 138, 183, 0.25);
+  box-shadow: 0 24px 60px rgba(10, 15, 30, 0.5);
+  overflow: hidden;
+  min-height: 360px;
+}
+
+.detail-view__image {
+  width: 100%;
+  max-width: 420px;
+  border-radius: 20px;
+  display: none;
+  box-shadow: 0 18px 38px rgba(8, 12, 24, 0.45);
+}
+
+.detail-view__image.is-active {
+  display: block;
+}
+
+.detail-view__badge {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  background: rgba(13, 15, 20, 0.7);
+  color: rgba(244, 246, 251, 0.85);
+}
+
 .testimonials {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -406,6 +489,14 @@ footer {
 
   .section {
     padding: 3rem 0;
+  }
+
+  .detail-view__layout {
+    gap: 2rem;
+  }
+
+  .detail-view__preview {
+    padding: 1.5rem;
   }
 
   .footer__content {


### PR DESCRIPTION
## Summary
- add a detail view section to the landing page that highlights the originals toggle
- implement a toggle button that swaps between the selfie and scene previews in the detail view
- style the new detail view layout and button to match the existing aesthetic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc9c7090cc832a8c9159bef3c6ceee