### PR TITLE
Fix broken footer links to policy documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,9 +226,9 @@
         <span class="footer__brand">© <span id="year"></span> InFrame Labs</span>
         <div class="footer__links">
           <a href="contact.html">Contact</a>
-          <a href="../PRIVACY_POLICY.md">Privacy Policy</a>
-          <a href="../TERMS_OF_USE.md">Terms of Use</a>
-          <a href="../IN_APP_DISCLOSURES.md">Disclosures</a>
+          <a href="PRIVACY_POLICY.md">Privacy Policy</a>
+          <a href="TERMS_OF_USE.md">Terms of Use</a>
+          <a href="IN_APP_DISCLOSURES.md">Disclosures</a>
         </div>
         <span>Made with SwiftUI in San Francisco.</span>
       </div>


### PR DESCRIPTION
## Summary
- correct the footer URLs for privacy, terms, and disclosure documents so they point to existing files

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d41455dbfc832a91920becf90057fe